### PR TITLE
Seperate Skryim SE and Skyrim AE

### DIFF
--- a/gamesinfo/skyrimanniversaryedition.sh
+++ b/gamesinfo/skyrimanniversaryedition.sh
@@ -6,10 +6,10 @@ game_proton_options="--native 'xaudio2_7' -e 'PULSE_LATENCY_MSEC=90'"
 game_wine_options="--native 'xaudio2_7'"
 game_protontricks=""
 game_winetricks=""
-game_scriptextender_url="https://skse.silverlock.org/beta/skse64_2_00_20.7z"
+game_scriptextender_url="https://skse.silverlock.org/beta/skse64_2_01_04.7z"
 game_scriptextender_files=( \
 	"skse64_2_01_04/Data" \
-	"skse64_2_01_04/skse64_1_5_97.dll" \
+	"skse64_2_01_04/skse64_1_6_342.dll" \
 	"skse64_2_01_04/skse64_loader.exe" \
 	"skse64_2_01_04/skse64_steam_loader.dll" \
 )

--- a/step/select_game.sh
+++ b/step/select_game.sh
@@ -24,6 +24,7 @@ selected_game=$( \
 		"oblivion" "Oblivion" \
 		"skyrim" "Skyrim" \
 		"skyrimspecialedition" "Skyrim Special Edition" \
+		"skyrimanniversaryedition" "Skyrim Anniversary Edition" \
 )
 
 if [ -z "$selected_game" ]; then


### PR DESCRIPTION
I have added the option to choose between Skyrim Special Edition and Skyrim Anniversary edition since these both need diffrent version of SKSE.
it will now choose the correct version of SKSE for these versions