### PR TITLE
Update AdoptOpenJDK to Adoptium

### DIFF
--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -3,7 +3,7 @@
 download="$utils/download.sh"
 extract="$utils/extract.sh"
 
-jdk_url='https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_windows_8u252b09.zip'
+jdk_url='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_windows_hotspot_8u312b07.zip'
 
 mo2_url='https://github.com/ModOrganizer2/modorganizer/releases/download/v2.2.2.1/Mod.Organizer-2.2.2.1.7z'
 


### PR DESCRIPTION
This is a new PR that only updates the JRE.
AdoptOpenJDK is now unsupported and doesnt recieve anymore updates, the same creators of it have rebranded to Adoptium.
in the time that ive used Adoptium everything seemed to have behaved correctly/the same as AdoptOpenJDk