### PR TITLE
Fixed overlapping path when STEAM_LIBRARY exists

### DIFF
--- a/utils/find-library-for-appid.sh
+++ b/utils/find-library-for-appid.sh
@@ -3,7 +3,7 @@
 appid=$1
 
 if [ -n "$STEAM_LIBRARY" ]; then
-	echo "$STEAM_LIBRARY/steamapps/compatdata/$appid"
+	echo "$STEAM_LIBRARY"
 	exit 0
 fi
 


### PR DESCRIPTION
Fixes #319, where the installer would fail due to an invalid `game_prefix` path when `STEAM_LIBRARY` is defined.