### PR TITLE
Forward first argument to MO2

### DIFF
--- a/steam-redirector/main.c
+++ b/steam-redirector/main.c
@@ -12,14 +12,12 @@
 #include "win32_utils.h"
 
 #define MO2_PATH_FILE "modorganizer2\\instance_path.txt"
-#define MO2_DOWNLOAD_PATH_FILE "modorganizer2\\instance_download_path.txt"
 
 #elif __unix__
 
 #include "unix_utils.h"
 
 #define MO2_PATH_FILE "modorganizer2/instance_path.txt"
-#define MO2_DOWNLOAD_PATH_FILE "modorganizer2/instance_download_path.txt"
 
 #endif
 
@@ -110,11 +108,12 @@ int main(int argc, char** argv) {
 #endif
 	int exit_status = 1;
 
+	char_t *arg = NULL;
 	if (argc > 1) {
-		exit_status = execute_from_path_file(MO2_DOWNLOAD_PATH_FILE, argv[1]);
-	} else {
-		exit_status = execute_from_path_file(MO2_PATH_FILE, NULL);
+		arg = argv[1];
 	}
+
+	exit_status = execute_from_path_file(MO2_PATH_FILE, arg);
 
 	return exit_status;
 }


### PR DESCRIPTION
A simple change that allows to pass an argument to MO2, mainly to bypass it and launch the game directly like the shortcuts created by MO2 do on Windows.

See issue #401 for a quick discussion about it.

With this change we are able to tell MO2 which executable it should run on startup to directly land into the game and bypass the run button, like we can do on Windows.

For example if SKSE is called "skse" in MO2's executables, setting Skyrim's launch option to `moshortcut://skse` will directly run SKSE through MO2.

Nexus downloads integration is still working in my case.