### PR TITLE
Hide console window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.orig
 
 /steam-redirector/main
-/steam-redirector/main.exe
+/steam-redirector/main*.exe
 
 /*.tar.gz
 

--- a/steam-redirector/Makefile
+++ b/steam-redirector/Makefile
@@ -10,5 +10,5 @@ main: main.c unix_utils.c
 	$(GNU_C) -o main unix_utils.c main.c
 
 main.exe: main.c win32_utils.c
-	$(WIN_C) -municode -static -static-libgcc -Bstatic -lpthread -o main.exe win32_utils.c main.c
+	$(WIN_C) -mwindows -municode -static -static-libgcc -Bstatic -lpthread -o main.exe win32_utils.c main.c
 

--- a/steam-redirector/Makefile
+++ b/steam-redirector/Makefile
@@ -12,3 +12,6 @@ main: main.c unix_utils.c
 main.exe: main.c win32_utils.c
 	$(WIN_C) -mwindows -municode -static -static-libgcc -Bstatic -lpthread -o main.exe win32_utils.c main.c
 
+main_debug.exe: main.c win32_utils.c
+	$(WIN_C) -municode -static -static-libgcc -Bstatic -lpthread -o main.exe win32_utils.c main.c
+

--- a/steam-redirector/Makefile
+++ b/steam-redirector/Makefile
@@ -1,5 +1,7 @@
 GNU_C=gcc
 WIN_C=x86_64-w64-mingw32-gcc
+WIN_FLAGS=-municode -static -static-libgcc -Bstatic -lpthread
+WIN_SRC=main.c win32_utils.c
 
 default: main.exe
 
@@ -9,9 +11,8 @@ all: main.exe main
 main: main.c unix_utils.c
 	$(GNU_C) -o main unix_utils.c main.c
 
-main.exe: main.c win32_utils.c
-	$(WIN_C) -mwindows -municode -static -static-libgcc -Bstatic -lpthread -o main.exe win32_utils.c main.c
+main.exe: $(WIN_SRC)
+	$(WIN_C) $(WIN_FLAGS) -mwindows -o main.exe $^
 
-main_debug.exe: main.c win32_utils.c
-	$(WIN_C) -municode -static -static-libgcc -Bstatic -lpthread -o main.exe win32_utils.c main.c
-
+main_debug.exe: $(WIN_SRC)
+	$(WIN_C) $(WIN_FLAGS) -o main_debug.exe $^


### PR DESCRIPTION
Pass the `-mwindows` parameter to mingw to hide the console that appears when running MO2 through the redirector.

IMO this should be the default but I can also undo my change and instead add a make target that build the redirector with this parameter.