### PR TITLE
Update script shebangs

### DIFF
--- a/ci/check-file-indentation.pl
+++ b/ci/check-file-indentation.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use autodie;
 use strict;

--- a/handlers/modorganizer2-nxm-broker.sh
+++ b/handlers/modorganizer2-nxm-broker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###    PARSE POSITIONAL ARGS    ###
 nxm_link=$1; shift

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cache_enabled="${CACHE:-1}"
 

--- a/pack-release.sh
+++ b/pack-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 version="$1"
 

--- a/step/apply_workarounds.sh
+++ b/step/apply_workarounds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 game_workarounds="$workarounds/$selected_game.sh"
 

--- a/step/check_dependencies.sh
+++ b/step/check_dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 missing_deps=()
 

--- a/step/configure_steam_wineprefix.sh
+++ b/step/configure_steam_wineprefix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "${game_protontricks[*]}" ]; then
 	log_info "applying protontricks ${game_protontricks[@]}"

--- a/step/confirm_initial_setup.sh
+++ b/step/confirm_initial_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 screen_text=$( \
 cat << EOF

--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 download="$utils/download.sh"
 extract="$utils/extract.sh"

--- a/step/install_external_resources.sh
+++ b/step/install_external_resources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function install_mo2() {
 	log_info "installing Mod Organizer 2 in '$mo2_installation'"

--- a/step/install_nxm_handler.sh
+++ b/step/install_nxm_handler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 log_info "installing nxm link broker in '$shared'"
 cp "$handlers/modorganizer2-nxm-broker.sh" "$shared"

--- a/step/install_steam_redirector.sh
+++ b/step/install_steam_redirector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p "$game_installation/modorganizer2"
 

--- a/step/load_gameinfo.sh
+++ b/step/load_gameinfo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 load_gameinfo="$gamesinfo/$selected_game.sh"
 

--- a/step/register_installation.sh
+++ b/step/register_installation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p "$HOME/.config/modorganizer2/instances"
 rm -f "$HOME/.config/modorganizer2/instances/$game_nexusid"

--- a/step/select_game.sh
+++ b/step/select_game.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 screen_text=$( \
 cat << EOF

--- a/step/select_install_dir.sh
+++ b/step/select_install_dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 picker_text=$( \
 cat << EOF

--- a/utils/dialog.sh
+++ b/utils/dialog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dialogtype=$1; shift
 

--- a/utils/find-library-for-appid.sh
+++ b/utils/find-library-for-appid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 appid=$1
 

--- a/utils/list-steam-libraries.sh
+++ b/utils/list-steam-libraries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function log_info() {
 	echo "INFO:" "$@" >&2

--- a/workarounds/enderal.sh
+++ b/workarounds/enderal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 data="$game_installation/Data"
 proc_patchers="$data/SkyProc Patchers"

--- a/workarounds/skyrim.sh
+++ b/workarounds/skyrim.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 data="$game_installation/Data"
 proc_patchers="$data/SkyProc Patchers"


### PR DESCRIPTION
Hello, I've ran into issues when trying to run the installer on my linux install because of the shebangs.

I did check that there is an already open PR about this issue. However, it contains some mistakes and is stale for almost 2 months. I didn't know if I could suggest commits and fixes to open PRs so I created another one (However, if it is possible and you prefer me to use the already open PR, please just tell me how).

As expected, this PR changes all bash shebangs from `#!/bin/bash` to `#!/usr/bin/env bash` and the single perl shebang from `#!/usr/bin/perl` to `#!/usr/bin/env perl`.

If there is any another issue, I'll try to fix it as soon as possible.

Thanks.