### PR TITLE
Check xdg-mime exists before calling it

### DIFF
--- a/step/install_nxm_handler.sh
+++ b/step/install_nxm_handler.sh
@@ -9,5 +9,9 @@ cp "$handlers/modorganizer2-nxm-handler.desktop" "$HOME/.local/share/application
 
 echo "$game_appid" > "$install_dir/appid.txt"
 
-xdg-mime default modorganizer2-nxm-handler.desktop x-scheme-handler/nxm
+if [ -n "$(command -v xdg-mime)" ]; then
+    xdg-mime default modorganizer2-nxm-handler.desktop x-scheme-handler/nxm
+else
+    log_warn "xdg-mime not found, cannot register mimetype"
+fi
 


### PR DESCRIPTION
Small fix to check if `xdg-mime` exists before running the command to support users who choose to forego `xdg-utils` in favor of more lightweight solutions, such as myself. This is done in `install_nxm_handler.sh` instead of in `check_dependencies.sh` since `xdg-mime` is not a hard dependency, and it's simpler to just check directly when it's called, since it's only called once. If `xdg-mime` was used more than once a more robust solution may be needed. 