### PR TITLE
Allow installation to continue when scriptextender files already present 

### DIFF
--- a/step/install_external_resources.sh
+++ b/step/install_external_resources.sh
@@ -54,7 +54,7 @@ function install_files() {
 				scriptextender_filepath="$extracted_scriptextender/$scriptextender_file"
 				log_info "copying '$scriptextender_filepath' into '$game_installation'"
 				if ! cp -an "$scriptextender_filepath" "$game_installation"; then
-				    log_warn "failed to copy '$scriptextender_filepath' into '$game_installation', file may already be present"
+					log_warn "failed to copy '$scriptextender_filepath' into '$game_installation', file may already be present"
 				fi
 			done
 		fi

--- a/step/install_external_resources.sh
+++ b/step/install_external_resources.sh
@@ -46,12 +46,16 @@ function install_files() {
 
 		if [ "${game_scriptextender_files[*]}" == "*" ]; then
 			log_info "copying all files from '$extracted_scriptextender' into '$game_installation'"
-			cp -an "$extracted_scriptextender"/* "$game_installation"
+			if ! cp -an "$extracted_scriptextender"/* "$game_installation"; then
+                log_warn "failed to copy all files from '$extracted_scriptextender' into '$game_installation', files may already be present"
+            fi
 		else
 			for scriptextender_file in "${game_scriptextender_files[@]}"; do
 				scriptextender_filepath="$extracted_scriptextender/$scriptextender_file"
 				log_info "copying '$scriptextender_filepath' into '$game_installation'"
-				cp -an "$scriptextender_filepath" "$game_installation"
+                if ! cp -an "$scriptextender_filepath" "$game_installation"; then
+                    log_warn "failed to copy '$scriptextender_filepath' into '$game_installation', file may already be present"
+                fi
 			done
 		fi
 	fi

--- a/step/install_external_resources.sh
+++ b/step/install_external_resources.sh
@@ -47,15 +47,15 @@ function install_files() {
 		if [ "${game_scriptextender_files[*]}" == "*" ]; then
 			log_info "copying all files from '$extracted_scriptextender' into '$game_installation'"
 			if ! cp -an "$extracted_scriptextender"/* "$game_installation"; then
-                log_warn "failed to copy all files from '$extracted_scriptextender' into '$game_installation', files may already be present"
-            fi
+				log_warn "failed to copy all files from '$extracted_scriptextender' into '$game_installation', files may already be present"
+			fi
 		else
 			for scriptextender_file in "${game_scriptextender_files[@]}"; do
 				scriptextender_filepath="$extracted_scriptextender/$scriptextender_file"
 				log_info "copying '$scriptextender_filepath' into '$game_installation'"
-                if ! cp -an "$scriptextender_filepath" "$game_installation"; then
-                    log_warn "failed to copy '$scriptextender_filepath' into '$game_installation', file may already be present"
-                fi
+				if ! cp -an "$scriptextender_filepath" "$game_installation"; then
+				    log_warn "failed to copy '$scriptextender_filepath' into '$game_installation', file may already be present"
+				fi
 			done
 		fi
 	fi

--- a/step/install_nxm_handler.sh
+++ b/step/install_nxm_handler.sh
@@ -9,5 +9,9 @@ cp "$handlers/modorganizer2-nxm-handler.desktop" "$HOME/.local/share/application
 
 echo "$game_appid" > "$install_dir/appid.txt"
 
-xdg-mime default modorganizer2-nxm-handler.desktop x-scheme-handler/nxm
+if [ -n "$(command -v xdg-mime)" ]; then
+    xdg-mime default modorganizer2-nxm-handler.desktop x-scheme-handler/nxm
+else
+    log_warn "xdg-mime not found, cannot register mimetype"
+fi
 

--- a/step/install_nxm_handler.sh
+++ b/step/install_nxm_handler.sh
@@ -9,9 +9,5 @@ cp "$handlers/modorganizer2-nxm-handler.desktop" "$HOME/.local/share/application
 
 echo "$game_appid" > "$install_dir/appid.txt"
 
-if [ -n "$(command -v xdg-mime)" ]; then
-    xdg-mime default modorganizer2-nxm-handler.desktop x-scheme-handler/nxm
-else
-    log_warn "xdg-mime not found, cannot register mimetype"
-fi
+xdg-mime default modorganizer2-nxm-handler.desktop x-scheme-handler/nxm
 


### PR DESCRIPTION
The installation fails and ends early if there is already script extender files in the game installation directory. This is inconvenient, since every time the installation is re-run the script extender files must be removed from the installation directory. 

This change throws a warning but allows the installation to continue if `cp` fails. While this also allows the isntallation to continue if `cp` fails for other reasons, IMO that's still an improvement since I would rather do the rest of the installation then fix the script extender manually afterwards, rather than fixing the issue then having to run the installation again.

(disregard the first/third commits, I accidentally branched from my other branch instead of `master`)