### PR TITLE
Don't create instance_download_path.txt

### DIFF
--- a/step/install_steam_redirector.sh
+++ b/step/install_steam_redirector.sh
@@ -4,16 +4,11 @@ mkdir -p "$game_installation/modorganizer2"
 
 installdir_windowspath="Z:$(tr '/' '\\' <<< "$install_dir")"
 mo2_executable_windowspath="$installdir_windowspath\\modorganizer2\\ModOrganizer.exe"
-mo2_nxmhandler_windowspath="$installdir_windowspath\\modorganizer2\\nxmhandler.exe"
 
 mo2_executable_path_config="$game_installation/modorganizer2/instance_path.txt"
-mo2_nxmhandler_path_config="$game_installation/modorganizer2/instance_download_path.txt"
 
 log_info "configuring mo2 executable path '$mo2_executable_windowspath' in '$mo2_executable_path_config'"
 echo "$mo2_executable_windowspath" > "$mo2_executable_path_config"
-
-log_info "configuring mo2 nxm handler path '$mo2_nxmhandler_windowspath' in '$mo2_nxmhandler_path_config'"
-echo "$mo2_nxmhandler_windowspath" > "$mo2_nxmhandler_path_config"
 
 original_game_executable="$game_installation/_$game_executable"
 
@@ -23,6 +18,6 @@ if [ ! -f "$original_game_executable" ]; then
 	mv "$full_game_executable_path" "$original_game_executable"
 fi
 
-	log_info "setting up redirector in '$full_game_executable_path'"
+log_info "setting up redirector in '$full_game_executable_path'"
 cp -f "$redirector/main.exe" "$full_game_executable_path"
 


### PR DESCRIPTION
As of #411, the `instance_download_path.txt` file is no longer used and there's no need to create it.