### PR TITLE
Rewrite dangerquestion dialog for better compatibility and visibility

### DIFF
--- a/utils/dialog.sh
+++ b/utils/dialog.sh
@@ -28,7 +28,7 @@ question() {
 }
 
 dangerquestion() {
-	zenity --question --ellipsize --icon-name=dialog-warning --text="$1"
+	zenity --extra-button=No --ok-label=Yes --warning --text="$1" >/dev/null
 	return $?
 }
 


### PR DESCRIPTION
Zenity has been reworking the icon options, causing recent versions to have different interfaces and making it impossible to reliably use icon related options without enforcing a specific Zenity version.
This rewrites the `dangerdialog` from the dialog utils to not rely on icon related features.

Additionally, the `--ellipsize` option has also been dropped. While it does have the downside of allowing the window to be larger, with a considerable amount of empty space, it fixes the visibility of the messages currently displayed within these windows.