### PR TITLE
Fix steam library iteration when library path contains spaces

### DIFF
--- a/utils/find-library-for-file.sh
+++ b/utils/find-library-for-file.sh
@@ -13,9 +13,8 @@ function log_info() {
 
 script_root=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 
-steam_libraries=($("$script_root/list-steam-libraries.sh"))
-
-for libdir in "${steam_libraries[@]}"; do
+"$script_root/list-steam-libraries.sh" | \
+while read -r libdir; do
 	full_path="$libdir/steamapps/common/$desired_file"
 	if [ -f "$full_path" ]; then
 		log_info "game found in '$libdir'"


### PR DESCRIPTION
Fixes #394.

`utils/list-steam-libraries.sh` prints a new-line separated list of Steam library paths. By default, Bash's internal field separator (IFS) is a combination of multiple characters, including spaces, which causes the creation of the array `steam_libraries` in `utils/find-library-for-file.sh` to separate items not only by new-lines (intended), but also spaces (unintended). This incorrect separation causes the main loop of the utility to iterate over a broken list of items when a library path contains spaces.

This solves the issue by piping the results of the library listing utility to a read loop, which will correctly iterate over each output line, without any additional item separation.