### PR TITLE
Raise error if user attempts to run the script as root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,12 @@ function log_error() {
 
 trap handle_error EXIT
 
+if [ "$UID" == "0" ]; then
+	log_error "Attempted to run as root"
+	log_error "Please follow the install instructions provided at https://github.com/rockerbacon/modorganizer2-linux-installer"
+	exit 1
+fi
+
 expect_exit=1
 
 source "$step/check_dependencies.sh"


### PR DESCRIPTION
I don't know if it's just a bad habit some people have or if someone wrote a bad guide somewhere, but there have been people opening issues after incorrectly running the script as the root user. A few examples include #556 #537 #325

This adds a quick check to prevent the script from running if a user attempts to run it as root and prompts the user to read the install instructions.

Hopefully no one out there legitimately uses Steam on a root account.