### PR TITLE
Include 'workarounds' directory in release packs

### DIFF
--- a/pack-release.sh
+++ b/pack-release.sh
@@ -20,6 +20,7 @@ release_files=( \
 	"steam-redirector/main.exe" \
 	"step" \
 	"utils" \
+	"workarounds" \
 )
 
 original_workdir=$PWD


### PR DESCRIPTION
Noticed today that the release script wasn't including the workarounds directory in the tarball.

Today's release (4.5.0) was made with the patched script from this PR and workarounds will be properly applied. Older releases are probably not applying workarounds.