### PR TITLE
Fix loading prefix information when game does not have a prefix

### DIFF
--- a/step/load_gameinfo.sh
+++ b/step/load_gameinfo.sh
@@ -28,7 +28,9 @@ if [ ! -d "$steam_library" ]; then
 	exit 1
 fi
 
-game_prefix=$("$utils/protontricks.sh" get-prefix "$game_appid")
-game_compatdata=$(dirname "$game_prefix")
 game_installation="$steam_library/steamapps/common/$game_steam_subdirectory"
+
+# defer loading these variables to step/clean_game_prefix.sh
+game_prefix=''
+game_compatdata=''
 

--- a/utils/protontricks.sh
+++ b/utils/protontricks.sh
@@ -47,8 +47,13 @@ function apply() {
 }
 
 function get_prefix() {
-	do_protontricks -c 'echo $WINEPREFIX' "$1"
-	return $?
+	prefix=$( \
+		do_protontricks -c 'echo $WINEPREFIX' "$1" 2>/dev/null || \
+		true \
+	)
+	if [ -d "$prefix" ]; then
+		echo "$prefix"
+	fi
 }
 
 action=$1


### PR DESCRIPTION
Closes #530 

The installer incorrectly expected a prefix to already exist before its execution, which may not be true in many circumstances. This PR fixes the issue by deferring the loading of prefix locations to the prefix clean-up step and adjusting the clean-up step to handle the case where a prefix does not yet exist.