### PR TITLE
Add Starfield support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following is a small overview of the current state of each supported game:
 | Oblivion               | working    | [some plugins might require manual setup](https://github.com/rockerbacon/lutris-skyrimse-installers/issues/63#issuecomment-643690247)                 | not tested    |
 | Skyrim                 | working       | working                   | working       |
 | Skyrim Special Edition | working       | working                   | not tested |
+| Starfield              | working (Proton 9.0+) | working           | not tested |
 
 For known bugs and necessary workarounds, please refer to the [issues page](https://github.com/rockerbacon/lutris-skyrimse-installers/issues?q=is:issue+is:open+label:bug+)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following is a small overview of the current state of each supported game:
 | Oblivion               | working    | [some plugins might require manual setup](https://github.com/rockerbacon/lutris-skyrimse-installers/issues/63#issuecomment-643690247)                 | not tested    |
 | Skyrim                 | working       | working                   | working       |
 | Skyrim Special Edition | working       | working                   | not tested |
-| Starfield              | working (Proton 9.0+) | working           | not tested |
+| Starfield              | working       | working                   | not tested |
 
 For known bugs and necessary workarounds, please refer to the [issues page](https://github.com/rockerbacon/lutris-skyrimse-installers/issues?q=is:issue+is:open+label:bug+)
 

--- a/gamesinfo/starfield.sh
+++ b/gamesinfo/starfield.sh
@@ -8,5 +8,4 @@ game_scriptextender_files=( \
 	"sfse_0_2_6/sfse_1_10_32.dll" \
 	"sfse_0_2_6/sfse_loader.exe" \
 )
-game_mo2_url="https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.0/Mod.Organizer-2.5.0.7z"
 

--- a/gamesinfo/starfield.sh
+++ b/gamesinfo/starfield.sh
@@ -1,0 +1,12 @@
+game_steam_subdirectory="Starfield"
+game_nexusid="starfield"
+game_appid=1716740
+game_executable="Starfield.exe"
+game_protontricks=("xaudio2_7=native")
+game_scriptextender_url="https://sfse.silverlock.org/download/sfse_0_2_6.7z"
+game_scriptextender_files=( \
+	"sfse_0_2_6/sfse_1_10_32.dll" \
+	"sfse_0_2_6/sfse_loader.exe" \
+)
+game_mo2_url="https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.0/Mod.Organizer-2.5.0.7z"
+

--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -5,7 +5,7 @@ extract="$utils/extract.sh"
 
 jdk_url='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_windows_hotspot_8u312b07.zip'
 
-mo2_url="${game_mo2_url:-https://github.com/ModOrganizer2/modorganizer/releases/download/v2.4.4/Mod.Organizer-2.4.4.7z}"
+mo2_url='https://github.com/ModOrganizer2/modorganizer/releases/download/v2.4.4/Mod.Organizer-2.4.4.7z'
 
 winetricks_url='https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks'
 

--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -5,7 +5,7 @@ extract="$utils/extract.sh"
 
 jdk_url='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_windows_hotspot_8u312b07.zip'
 
-mo2_url='https://github.com/ModOrganizer2/modorganizer/releases/download/v2.4.4/Mod.Organizer-2.4.4.7z'
+mo2_url="${game_mo2_url:-https://github.com/ModOrganizer2/modorganizer/releases/download/v2.4.4/Mod.Organizer-2.4.4.7z}"
 
 winetricks_url='https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks'
 

--- a/step/select_game.sh
+++ b/step/select_game.sh
@@ -27,6 +27,7 @@ selected_game=$( \
 		"skyrim" "Skyrim" \
 		"skyrimspecialedition" "Skyrim Special Edition" \
 		"skyrimvr" "Skyrim VR" \
+		"starfield" "Starfield"\
 )
 
 if [ -z "$selected_game" ]; then

--- a/workarounds/starfield.sh
+++ b/workarounds/starfield.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+sfse_config_dir="$game_installation/Data/SFSE"
+
+mkdir -p "$sfse_config_dir"
+
+cat << EOT >> "$sfse_config_dir/SFSE.ini"
+[Loader]
+RuntimeName=_Starfield.exe
+EOT


### PR DESCRIPTION
Hello, I'm pretty new to using GitHub so apologies if this isn't the right way of doing this.

I've added support for Starfield based on the comments here: #528

Since this requires MO2 v2.5.0, I added a mechanism for overriding the `mo2_url` via `game_mo2_url` in the `gamesinfo` scripts. It's also necessary to use Proton 9.0 (beta). And I needed to add a workaround for `Data/SFSE/SFSE.ini` to point to `_Starfield.exe`, similar to the Skyrim VR workaround.

I installed a handful of the popular mods and that all seemed to work. Would be good to have some others test it out as well.

It does feel a bit hacky to use `game_mo2_url` like this though, so I'm open to waiting until we've got the Proton 9 and MO2 v2.5.0 changes in place.