### PR TITLE
Add support for Wget2

### DIFF
--- a/step/check_dependencies.sh
+++ b/step/check_dependencies.sh
@@ -6,7 +6,7 @@ if [ -z "$(command -v 7z)" ]; then
 	missing_deps+=(7z)
 fi
 
-if [ -z "$(command -v curl)" ] && [ -z "$(command -v wget)" ]; then
+if [ -z "$(command -v curl)" ] && [ -z "$(command -v wget)" ] && [ -z "$(command -v wget2)" ]; then
 	missing_deps+=("curl or wget")
 fi
 

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -28,6 +28,9 @@ fi
 # don't have a name e.g. https://example.com/.
 if [ -n "$DOWNLOAD_BACKEND" ]; then
 	download_backend="$DOWNLOAD_BACKEND"
+elif command -v wget >& /dev/null && command wget --version|grep Wget2 >& /dev/null; then
+	log_info "using wget2 backend"
+	download_backend="wget2"
 elif command -v wget >& /dev/null; then
 	log_info "using wget backend"
 	download_backend="wget"
@@ -46,6 +49,12 @@ progress_text="Downloading '${out_file##*/}'"
 log_info "downloading '$url' to '$out_file'"
 
 case "$download_backend" in
+	"wget2")
+		wget "$url" --progress=dot --no-verbose -O "$out_file" 2>&1 \
+			| grep --line-buffered --color=never -oE '[0-9]+%' \
+			| zenity --progress --auto-kill --auto-close --text="$progress_text"
+		;;
+		
 	"wget")
 		wget "$url" --progress=dot --no-verbose --show-progress -O "$out_file" 2>&1 \
 			| grep --line-buffered --color=never -oE '[0-9]+%' \

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -50,7 +50,7 @@ log_info "downloading '$url' to '$out_file'"
 
 case "$download_backend" in
 	"wget2")
-		wget "$url" --progress=dot --no-verbose -O "$out_file" 2>&1 \
+		wget "$url" --no-verbose -O "$out_file" 2>&1 \
 			| grep --line-buffered --color=never -oE '[0-9]+%' \
 			| zenity --progress --auto-kill --auto-close --text="$progress_text"
 		;;

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -28,7 +28,7 @@ fi
 # don't have a name e.g. https://example.com/.
 if [ -n "$DOWNLOAD_BACKEND" ]; then
 	download_backend="$DOWNLOAD_BACKEND"
-elif command -v wget >& /dev/null && wget --version|grep Wget2 >& /dev/null; then
+elif command -v wget2 >& /dev/null; then
 	log_info "using wget2 backend"
 	download_backend="wget2"
 elif command -v wget >& /dev/null; then
@@ -50,7 +50,7 @@ log_info "downloading '$url' to '$out_file'"
 
 case "$download_backend" in
 	"wget2")
-		wget "$url" --no-verbose -O "$out_file" 2>&1 \
+		wget2 "$url" --no-verbose --force-progress -O "$out_file" 2>&1 \
 			| grep --line-buffered --color=never -oE '[0-9]+%' \
 			| zenity --progress --auto-kill --auto-close --text="$progress_text"
 		;;

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -28,7 +28,7 @@ fi
 # don't have a name e.g. https://example.com/.
 if [ -n "$DOWNLOAD_BACKEND" ]; then
 	download_backend="$DOWNLOAD_BACKEND"
-elif command -v wget >& /dev/null && command wget --version|grep Wget2 >& /dev/null; then
+elif command -v wget >& /dev/null && wget --version|grep Wget2 >& /dev/null; then
 	log_info "using wget2 backend"
 	download_backend="wget2"
 elif command -v wget >& /dev/null; then

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -56,8 +56,7 @@ log_info "downloading '$url' to '$out_file'"
 case "$download_backend" in
 	"wget2")
 		wget2 "$url" --no-verbose --force-progress -O "$out_file" 2>&1 \
-			| grep --line-buffered --color=never -oE '[0-9]+%' \
-			| zenity --progress --auto-kill --auto-close --text="$progress_text"
+			| progress_bar "$progress_text"
 		;;
 		
 	"wget")


### PR DESCRIPTION
Added support for Wget2 in the download.sh script.

It would now also check if "wget --version" contains "Wget2".
If it does, the script will say that it uses wget2 and will omit the --show-progress option that wget2 doesn't understand.
Hopefully, it will work the same way on wget earlier than 2 (testing probably needed)

There's probably a better way to do this, but I'm not experienced enough.