### PR TITLE
Don't suppress protontricks error messages when getting prefix

### DIFF
--- a/step/clean_game_prefix.sh
+++ b/step/clean_game_prefix.sh
@@ -85,7 +85,7 @@ if [ -z "$game_prefix" ]; then
 	log_error "no prefix found"
 	"$dialog" \
 		errorbox \
-		"A prefix for the selected game could not be found.\nMake sure you have followed the instructions\non creating a clean prefix"
+		"A prefix for the selected game could not be found.\nMake sure you have followed the instructions on creating a clean prefix.\nCheck the terminal output for more details."
 	exit 1
 fi
 

--- a/utils/protontricks.sh
+++ b/utils/protontricks.sh
@@ -47,12 +47,22 @@ function apply() {
 }
 
 function get_prefix() {
-	prefix=$( \
-		do_protontricks -c 'echo $WINEPREFIX' "$1" 2>/dev/null || \
-		true \
+	local visible=$(do_protontricks -l | grep -o "$1")
+	if [ -z "$visible" ]; then
+		return 0
+	fi
+
+	local stdout=$( \
+		do_protontricks -c 'echo $WINEPREFIX' "$1" || true \
 	)
-	if [ -d "$prefix" ]; then
-		echo "$prefix"
+
+	if [ -d "$stdout" ]; then
+		echo "$stdout"
+	else
+		log_error \
+			"Protontricks did not find a valid prefix directory. " \
+			"Stdout was:\n$stdout"
+		return 1
 	fi
 }
 


### PR DESCRIPTION
Closes #590 

Improves error detection while searching for the Proton prefix location by:
1. Checking if Protontricks can see the game before attempting to find the prefix. If it cannot see the game, the prefix either doesn't exist or Protontricks is broken
2. Not suppressing Protontricks error logs when finding the prefix location

Not a solution to anything, but at least helps break down possible Protontricks errors a little more.