### PR TITLE
Update Mo2 to V2.5

### DIFF
--- a/post-install.md
+++ b/post-install.md
@@ -20,7 +20,7 @@ This document provides information on additional steps you may want to take afte
 
 ## Using alternative proton versions
 
-**IMPORTANT:** Proton 6.3 is the most extensively tested version. The author of this document provides no guarantees that alternative versions will work well.
+**IMPORTANT:** Proton 9.0 is the most extensively tested version. The author of this document provides no guarantees that alternative versions will work well.
 
 1. Close the game and Mod Organizer 2 if you have them open;
 2. Select the Proton version you'd like to use on Steam and wait for it to execute any validations and updates;

--- a/step/clean_game_prefix.sh
+++ b/step/clean_game_prefix.sh
@@ -15,7 +15,7 @@ Now you need to create a clean prefix:
 1. On Steam: right click the game > Properties > Compatibility
 2. Check the option "Force the use of a specific Steam Play compatibility tool"
 3. Select the Proton version you would like to use
-	* Proton 8.0 is the currently supported and recommended version
+	* Proton 9.0 is the currently supported and recommended version
 4. Launch the game and wait for Steam to finish its setup
 5. Close the game. It must remain stopped through the entire install process
 EOF

--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -5,7 +5,7 @@ extract="$utils/extract.sh"
 
 jdk_url='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_windows_hotspot_8u312b07.zip'
 
-mo2_url='https://github.com/ModOrganizer2/modorganizer/releases/download/v2.4.4/Mod.Organizer-2.4.4.7z'
+mo2_url='https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.0/Mod.Organizer-2.5.0.7z'
 
 winetricks_url='https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks'
 


### PR DESCRIPTION
Proton 9.0 is now stable and can be used to launch Mo2 v2.5!

I have tested and it runs perfectly for me

can confirm this fixes #362