### PR TITLE
Set "automatically capture mouse in full-screen windows" wine option for FO4.

### DIFF
--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Fallout 4"
 game_nexusid="fallout4"
 game_appid=377160
 game_executable="Fallout4Launcher.exe"
-game_protontricks=("xaudio2_7=native")
+game_protontricks=("xaudio2_7=native" "grabfullscreen=y")
 game_scriptextender_url="https://f4se.silverlock.org/beta/f4se_0_06_23.7z"
 game_scriptextender_files="*"
 


### PR DESCRIPTION
Needed for multi-montor support.  See issue #648.