### PR TITLE
Do not install F4SE

### DIFF
--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -3,6 +3,6 @@ game_nexusid="fallout4"
 game_appid=377160
 game_executable="Fallout4Launcher.exe"
 game_protontricks=("xaudio2_7=native" "grabfullscreen=y")
-game_scriptextender_url="https://f4se.silverlock.org/beta/f4se_0_06_23.7z"
-game_scriptextender_files="*"
+game_scriptextender_url=""
+game_scriptextender_files=""
 


### PR DESCRIPTION
As discussed in #651, F4SE 0.6.23 does not work with the latest game version on Steam and the F4SE team has not yet made compatible builds available outside of Nexus.

This removes installation of F4SE altogether as a temporary measure to prevent broken F4SE setups.