### PR TITLE
Fix unbound script extender variables when no script extender url exists

### DIFF
--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -17,6 +17,9 @@ executable_winetricks="$shared/winetricks"
 downloaded_mo2="$downloads_cache/${mo2_url##*/}"
 extracted_mo2="${downloaded_mo2%.*}"
 
+downloaded_scriptextender=""
+extracted_scriptextender=""
+
 if [ -n "$game_scriptextender_url" ]; then
 	downloaded_scriptextender="$downloads_cache/${game_nexusid}_${game_scriptextender_url##*/}"
 	extracted_scriptextender="${downloaded_scriptextender%.*}"


### PR DESCRIPTION
Fixes #658 