### PR TITLE
Update fallout3_goty.sh with correct executable filename

### DIFF
--- a/gamesinfo/fallout3_goty.sh
+++ b/gamesinfo/fallout3_goty.sh
@@ -1,5 +1,5 @@
 game_appid=22370
-game_executable="FalloutLauncherSteam.exe"
+game_executable="Fallout3Launcher.exe"
 game_nexusid="fallout3"
 game_steam_subdirectory="Fallout 3 goty"
 game_protontricks=("d3dcompiler_43" "d3dx9")


### PR DESCRIPTION
FalloutLauncherSteam.exe does not exist and causes errors upon installation. I updated the game_executable to be the correct "Fallout3Launcher.exe" and was able to install MO2 without issue