### PR TITLE
Add STEAM_DIR env var to list-steam-libraries.sh

### DIFF
--- a/utils/list-steam-libraries.sh
+++ b/utils/list-steam-libraries.sh
@@ -7,7 +7,7 @@ function log_info() {
 steam_install_candidates=( \
 	"$(readlink -f "$HOME/.steam/root")" \
 	"$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam" \
- 	"$STEAM_DIR" \
+	"$STEAM_DIR" \
 )
 
 for steam_install in "${steam_install_candidates[@]}"; do

--- a/utils/list-steam-libraries.sh
+++ b/utils/list-steam-libraries.sh
@@ -7,6 +7,7 @@ function log_info() {
 steam_install_candidates=( \
 	"$(readlink -f "$HOME/.steam/root")" \
 	"$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam" \
+ 	"$STEAM_DIR" \
 )
 
 for steam_install in "${steam_install_candidates[@]}"; do


### PR DESCRIPTION
Add the STEAM_DIR envrionment variable to the steam_install_candidates array in /utils/list-steam-libraries.sh

This allowed the script/s to find my steam install directory.