### PR TITLE
Fix missing square bracket error in nxm broker

### DIFF
--- a/handlers/modorganizer2-nxm-broker.sh
+++ b/handlers/modorganizer2-nxm-broker.sh
@@ -15,7 +15,7 @@ nexus_game_id=${nexus_game_id%%/*}
 instance_link="$HOME/.config/modorganizer2/instances/${nexus_game_id:?}"
 instance_dir=$(readlink -f  "$instance_link")
 if [ ! -d "$instance_dir" ]; then
-	[ -L "$instance_link"] && rm "$instance_link"
+	[ -L "$instance_link" ] && rm "$instance_link"
 
 	zenity --ok-label=Exit --error --text \
 		"Could not download file because there is no Mod Organizer 2 instance for '$nexus_game_id'"


### PR DESCRIPTION
When attempting to download for a game in which no Mod Organizer 2 instance has been set up, the following error is emitted:

    line 18: [: missing `]'

This patch fixes the error by adding the required space character!